### PR TITLE
[SH-170] 게임 화면 내에 카드 배치 기능 구현

### DIFF
--- a/src/components/game/DroppableCell.tsx
+++ b/src/components/game/DroppableCell.tsx
@@ -1,0 +1,21 @@
+import { useDroppable } from "@dnd-kit/core";
+import { type ReactNode } from "react";
+
+interface DroppableCellProps {
+    id: string;
+    children: ReactNode;
+}
+
+export const DroppableCell: React.FC<DroppableCellProps> = ({ id, children }) => {
+    const { setNodeRef, isOver } = useDroppable({
+        id,
+    });
+    return (
+        <div
+            ref={setNodeRef}
+            className={`w-full h-full ${isOver ? "bg-[#ccf3ff]" : "bg-white/20"}`}
+        >
+            {children}
+        </div>
+    );
+}; 

--- a/src/components/game/Map.tsx
+++ b/src/components/game/Map.tsx
@@ -21,10 +21,10 @@ export const GameMap: React.FC<GameMapProps> = ({
 				<div
 					key={`${row}-${col}`}
 					style={{
-						width: 80,
-						height: 80,
+						width: 74,
+						height: 112,
 						border: "1px solid #bbb",
-						background: "#fff",
+						// background: "#fff",
 						display: "flex",
 						alignItems: "center",
 						justifyContent: "center",
@@ -45,7 +45,7 @@ export const GameMap: React.FC<GameMapProps> = ({
 	return (
 		<div
 			style={{
-				background: "#eee",
+				// background: "#eee",
 				display: "inline-block",
 				...style,
 			}}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,14 +1,24 @@
 import type React from "react";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useBackgroundActions } from "@/stores/common/BackgroundStore";
 import roomBackground from "@/assets/room.png";
 import PlayerPanel from "@/components/ui/PlayerPanel";
 import remainCard from "@/assets/card/routeH1.png";
 import transhCan from "@/assets/trash.png";
 import rotateIcon from "@/assets/rotate.png";
-
-import routeCard from "@/assets/card/routeTRBL1.png";
 import roleCard from "@/assets/roleCard/saboteur.png";
+import {
+	DndContext,
+	type DragEndEvent,
+	type DragOverEvent,
+	type DragStartEvent,
+} from "@dnd-kit/core";
+import { toast } from "sonner";
+import { horizontalListSortingStrategy, SortableContext } from "@dnd-kit/sortable";
+import GameMap from "@/components/game/Map";
+import RouteCard from "@/components/asset/RouteCard";
+import { DroppableCell } from "@/components/game/DroppableCell";
+import update from "immutability-helper";
 
 const GamePage: React.FC = () => {
 	const { setImage, setUseLayout } = useBackgroundActions();
@@ -18,6 +28,7 @@ const GamePage: React.FC = () => {
 		setUseLayout(false);
 	}, [setImage, setUseLayout]);
 
+    // 플레이어 관련
 	type ToolState = "normal" | "broken";
 
 	type Player = {
@@ -56,58 +67,179 @@ const GamePage: React.FC = () => {
 		}
 	});
 
+    // 카드 관련
+    type CardData = {
+        id: string;
+        row: number;
+        col: number;
+        direction: Array<"top" | "right" | "bottom" | "left">;
+    };
+    const initialMyCards: CardData[] = [
+        { id: "mycard-1", direction: ["top", "right", "bottom", "left"], row: 0, col: 0 },
+        { id: "mycard-2", direction: ["top", "bottom"], row: 2, col: 1 },
+    ];
+    const initialCards: CardData[] = [
+        { id: "", direction: ["top", "right", "bottom", "left"], row: 0, col: 0 },
+        { id: "", direction: ["top", "bottom"], row: 2, col: 1 },
+    ];
+
+    const [myCards, setMyCards] = useState<CardData[]>(initialMyCards);
+	const [cards, setCards] = useState<CardData[]>(initialCards);
+
+    const cardAt = (row: number, col: number) => {
+		return cards.find((c) => c.row === row && c.col === col);
+	};
+
+    // 드래그 이벤트 핸들러
+    const handleDragStart = (e: DragStartEvent) => {
+		toast.info(`Drag Start: ${JSON.stringify(e)}`);
+	};
+
+	const handleDragOver = (e: DragOverEvent) => {
+		toast.info(`Drag Over on ${e.over?.id}`);
+	};
+
+	const handleDragEnd = (e: DragEndEvent) => {
+		const { active, over } = e;
+		if (!over) return;
+
+		toast.info(`Active: ${JSON.stringify(active)}`);
+		toast.info(`Over: ${JSON.stringify(over)}`);
+
+		// 게임보드에 카드 배치
+		if (
+			active.id.toString().startsWith("mycard") &&
+			over.id.toString().startsWith("cell")
+		) {
+			const activeIndex = myCards.findIndex((data) => data.id === active.id);
+
+			const [_, rowStr, colStr] = over.id.toString().split("-");
+			const row = Number.parseInt(rowStr, 10);
+			const col = Number.parseInt(colStr, 10);
+
+			setCards((prev) =>
+				update(prev, {
+					$push: [
+						{
+							id: "",
+							row: row,
+							col: col,
+							direction: myCards[activeIndex].direction,
+						},
+					],
+				}),
+			);
+		}
+
+		// 카드 덱 내 카드 순서 변경
+		if (
+			active.id.toString().startsWith("mycard") &&
+			over.id.toString().startsWith("mycard")
+		) {
+			const activeIndex = myCards.findIndex((data) => data.id === active.id);
+			const overIndex = myCards.findIndex((data) => data.id === over.id);
+			setMyCards((prev) =>
+				update(
+					update(prev, { $splice: [[activeIndex, 1, myCards[overIndex]]] }),
+					{ $splice: [[overIndex, 1, myCards[activeIndex]]] },
+				),
+			);
+		}
+	};
+
 	return (
 		<div className="relative h-screen">
-			{/* 플레이어 패널 */}
-			<div className="flex justify-between pt-10">
-				<div className="flex flex-col gap-3">
-					{leftPlayers.map((player) => (
-						<PlayerPanel key={player.id} player={player} position="left" />
-					))}
-				</div>
-				<div className="flex flex-col gap-3 items-end">
-					{rightPlayers.map((player) => (
-						<PlayerPanel key={player.id} player={player} position="right" />
-					))}
-				</div>
-			</div>
-            {/* 남은 카드 */}
-            <div className="absolute bottom-2 left-75">
-                <img src={remainCard} className="w-18" />
-                <p className="absolute top-1 left-1/2 -translate-x-1/2 text-white text-lg font-holtwood">64</p>
-            </div>
-            {/* 카드 덱 */}
-            <div className="absolute bottom-0 left-1/2 -translate-x-1/2"> 
-                <div className="flex gap-5 w-[580px] h-42 bg-black/30 rounded-tl-xl rounded-tr-xl pt-4 px-6 pb-2 overflow-hidden">
-                    {Array(6).fill(0).map((_, i) => (
-                        <div key={i} className="group flex flex-col justify-between items-center shrink-0 w-[72px]">
-                            <img
-                                src={rotateIcon}
-                                className="opacity-0 group-hover:opacity-100 transition-opacity"
-                                onClick={() => {}} // 카드 회전 기능 추가 필요
-                            />
-                            <img
-                                src={routeCard}
-                                className="w-full h-auto object-contain rounded-sm border border-white self-end"
-                            />
+            <DndContext
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDragEnd={handleDragEnd}
+            >
+                {/* 플레이어 패널 */}
+                <div className="flex justify-between pt-10">
+                    <div className="flex flex-col gap-3">
+                        {leftPlayers.map((player) => (
+                            <PlayerPanel key={player.id} player={player} position="left" />
+                        ))}
+                    </div>
+                    <div className="flex flex-col gap-3 items-end">
+                        {rightPlayers.map((player) => (
+                            <PlayerPanel key={player.id} player={player} position="right" />
+                        ))}
+                    </div>
+                </div>
+
+                {/* 게임 보드 */}
+                <div className="absolute top-10 left-1/2 -translate-x-1/2">
+                    <GameMap
+                        width={9}
+                        height={5}
+                        renderCell={(row, col) => (
+                            <DroppableCell id={`cell-${row}-${col}`}>
+                                {cardAt(row, col) && (
+                                    <RouteCard
+                                        id={`card-${row}-${col}`}
+                                        isBlock={false}
+                                        isHidden={false}
+                                        direction={cardAt(row, col)!.direction}
+                                        isDraggable={false}
+                                    />
+                                )}
+                            </DroppableCell>
+                        )}
+                    />
+                </div>
+
+                {/* 남은 카드 */}
+                <div className="absolute bottom-2 left-75">
+                    <img src={remainCard} className="w-18" />
+                    <p className="absolute top-1 left-1/2 -translate-x-1/2 text-white text-lg font-holtwood">64</p>
+                </div>
+
+                {/* 카드 덱 */}
+                <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
+                    <SortableContext
+                        items={myCards.map((data) => data.id)}
+                        strategy={horizontalListSortingStrategy}
+                    >
+                        <div className="flex gap-5 w-[580px] h-42 bg-black/30 rounded-tl-xl rounded-tr-xl pt-4 px-6 pb-2 overflow-hidden">
+                            {myCards.map((data) => (
+                                <div key={data.id} className="group flex flex-col justify-between items-center shrink-0 w-[72px]">
+                                    <img
+                                        src={rotateIcon}
+                                        className="opacity-0 group-hover:opacity-100 transition-opacity"
+                                        onClick={() => {}} // 카드 회전 기능 추가 필요
+                                    />
+                                    <RouteCard
+                                        id={data.id}
+                                        isBlock={false}
+                                        isHidden={false}
+                                        direction={data.direction}
+                                        isDraggable={true}
+                                    />
+                                </div>
+                            ))}
                         </div>
-                    ))}
+                    </SortableContext>
                 </div>
-            </div>
-            {/* 버리기 */}
-            <div className="absolute bottom-2 right-75 h-28">
-                <div className="h-28 flex flex-col justify-between items-center">
-                    <p className="text-white text-xl font-holtwood font-bold">버리기</p>
-                    <img src={transhCan} className="w-19" />
+
+                {/* 버리기 */}
+                <div className="absolute bottom-2 right-75 h-28">
+                    <DroppableCell id="trash">
+                        <div className="h-28 flex flex-col justify-between items-center">
+                            <p className="text-white text-xl font-holtwood font-bold">버리기</p>
+                            <img src={transhCan} className="w-19" />
+                        </div>
+                    </DroppableCell>
                 </div>
-            </div>
-            {/* 역할 카드 */}
-            <div className="absolute bottom-0 right-13"> 
-                <div className="w-37 h-42 bg-black/30 rounded-tl-xl rounded-tr-xl pt-4 px-6 pb-2 flex flex-col gap-1">
-                    <p className="text-xl font-holtwood font-bold uppercase text-[#DF1E34] text-shadow-[0_-1.46px_0.73px_#FFFFFFCC,0_1.46px_2.19px_#000000]">ROLE</p>
-                    <img src={roleCard} className="w-18 flex-1 object-contain mx-auto" />
+
+                {/* 역할 카드 */}
+                <div className="absolute bottom-0 right-13"> 
+                    <div className="w-37 h-42 bg-black/30 rounded-tl-xl rounded-tr-xl pt-4 px-6 pb-2 flex flex-col gap-1">
+                        <p className="text-xl font-holtwood font-bold uppercase text-[#DF1E34] text-shadow-[0_-1.46px_0.73px_#FFFFFFCC,0_1.46px_2.19px_#000000]">ROLE</p>
+                        <img src={roleCard} className="w-18 flex-1 object-contain mx-auto" />
+                    </div>
                 </div>
-            </div>
+            </DndContext>
 		</div>
 	);
 };

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,14 +1,14 @@
 import { useBackgroundActions } from "@/stores/common/BackgroundStore";
 import roomBackground from "@/assets/room.png";
-import { type ReactNode, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import RouteCard from "@/components/asset/RouteCard";
 import GameMap from "@/components/game/Map";
+import { DroppableCell } from "@/components/game/DroppableCell";
 import {
 	DndContext,
 	type DragEndEvent,
 	type DragOverEvent,
 	type DragStartEvent,
-	useDroppable,
 } from "@dnd-kit/core";
 import { toast } from "sonner";
 import {
@@ -153,22 +153,3 @@ const TestPage: React.FC = () => {
 };
 
 export default TestPage;
-
-interface DroppableCellProps {
-	id: string;
-	children: ReactNode;
-}
-
-const DroppableCell: React.FC<DroppableCellProps> = ({ id, children }) => {
-	const { setNodeRef, isOver } = useDroppable({
-		id,
-	});
-	return (
-		<div
-			ref={setNodeRef}
-			className={`w-full h-full ${isOver ? "bg-[#ccf3ff]" : "bg-white"}`}
-		>
-			{children}
-		</div>
-	);
-};


### PR DESCRIPTION
<!-- PR제목 예시: [SH-12] 로그인 기능 구현 -->

## 📌 관련 이슈
- Jira: [SH-170](https://snowhite.atlassian.net/browse/SH-170?atlOrigin=eyJpIjoiZmUzZGVjN2FlMDg2NDUxNGIwMTBmNmI2OWIxNWZjNjUiLCJwIjoiaiJ9)

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
게임 진행 화면 내에 게임보드를 배치하고, 사용자 덱의 카드 순서 변경 및 게임보드로 드래그 앤 드랍 기능을 구현하였습니다.

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 게임보드의 크기를 5x9로 수정하고, 셀 크기도 카드 크기에 맞게 수정하였습니다.
- 드랍 가능한 셀의 배경 색을 피그마 디자인에 맞추어 투명하게 보이도록 변경하였습니다.
- 화면 전체를 드래그 가능 영역으로 설정하였습니다. 화면 가운데에 게임보드를 배치했고, 카드 덱에 있는 카드를 보드에 배치할 수 있도록 했습니다.
- 카드는 버리기 아이콘으로도 드래그 앤 드랍이 가능합니다. 버리기 행동에 따른 UI 변화는 따로 구현하지 않은 상태입니다.
- TestPage.tsx의 DroppableCell을 게임에서 사용하기 위해 컴포넌트로 분리하였습니다. ( `@/components/game/DroppableCell.tsx` )

## 🧪 테스트 체크리스트
- [ ] /game 접속 후 사용자 덱의 카드 드래그 앤 드랍, 순서 변경 기능 작동 확인

## 💬 추가 사항


## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-170]: https://snowhite.atlassian.net/browse/SH-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ