### PR TITLE
[FEAT] 방장 퇴장 시 남아있는 잔여 플레이어 방 목록 페이지로 자동 라우팅

### DIFF
--- a/src/pages/Waiting.tsx
+++ b/src/pages/Waiting.tsx
@@ -38,8 +38,13 @@ const WaitingPage: React.FC = () => {
 			pushChat(msg);
 		};
 
+		const handleQuitRoom = () => {
+			navigate("/room");
+		}
+
 		socket.onRoomusers(handleMessage);
 		socket.onChat(handleChat);
+		socket.onQuitRoom(handleQuitRoom);
 		open();
 		return () => {
 			socket.offRoomusers(handleMessage);

--- a/src/sockets/RoomSocket.ts
+++ b/src/sockets/RoomSocket.ts
@@ -94,4 +94,8 @@ export class RoomSocket extends BaseSocket {
 	public offChat(callback: (payload: ChatResponse) => void) {
 		this.off("chat", callback);
 	}
+
+	public onQuitRoom(callback: (payload: any) => void) {
+		this.on("quit-success", callback);
+	}
 }


### PR DESCRIPTION
<!-- PR제목 예시: [SH-12] 로그인 기능 구현 -->

## 📌 관련 이슈
- Jira: [SH-200](https://snowhite.atlassian.net/browse/SH-200?atlOrigin=eyJpIjoiZDFjMGVkM2UzNTI1NDEwMWFlODQwNDY4OTVmYzc1MGQiLCJwIjoiaiJ9)

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
백엔드에서 변경된 사항에 맞춰, 방장이 방 퇴장 시 방에 남아있는 유저들 또한 방에서 나가 방 목록 페이지로 자동 라우팅 되도록 구현

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- roomSocket "quit-success" 응답 수신 설정
- 방장 퇴장 후 "quit-success" 응답 수신 시 `/room` 페이지로 라우팅 설정

## 🧪 테스트 체크리스트
- [ ] 방장 유저가 나가기 버튼 클릭 시 방 목록 `/room` 페이지로 라우팅 확인
- [ ] 방장 유저가 나가기 버튼 클릭 후 잔여 플레이어 또한 `/room` 페이지로 라우팅 되는지 확인

## 💬 추가 사항
특이사항 없음

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-200]: https://snowhite.atlassian.net/browse/SH-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ