### PR TITLE
[FIX] 목적지에 가는 모든 카드들 지도 카드로 사용으로 처리되는 문제 해결

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -152,8 +152,10 @@ const GamePage: React.FC = () => {
 				const col = Number(colStr);
 
 				// 지도카드는 특정 위치만 허용
-				if ((row === 1 || row === 3 || row === 5) && col === 8) {
+				if ((row === 1 || row === 3 || row === 5) && col === 8 && cardId === 108) {
 					useMapCard(cardId, row, col);
+				} else if (cardId !== 108) {
+					toast("목적지 카드에는 지도 카드만 사용할 수 있습니다.");
 				}
 
 				// 플레이어에 드랍 (수리/부서짐카드)


### PR DESCRIPTION
<!-- PR제목 예시: [SH-12] 로그인 기능 구현 -->
## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
목적지 카드로 향하는 모든 카드들이 useMapCard 함수 호출하는 문제 해결

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- `useMapCard` 함수 호출 전 지도 카드에 해당하는 108번 번호의 카드인지 확인하는 조건 추가
- 지도 카드인 108번이 아닌 카드가 목적지 카드에 사용될 시 에러 메시지 출력

## 🧪 테스트 체크리스트
- [ ] 목적지 카드에 낙석 카드 사용 시 화면 오른쪽 하단 에러 메시지 확인
- [ ] 목적지 카드에 낙석 카드 사용 후 브라우저 개발자 모드의 네트워크 창에서 `use-map-card` 호출 안되는 것 확인

## 💬 추가 사항
급하게 생긴 수정 사항이라 지라에 이슈 따로 추가하지 않았습니다.

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?